### PR TITLE
Add broken-image pre-commit hook for internal refs (closes #34)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,12 @@ repos:
         language: system
         types_or: [image, svg]
 
+      - id: image-refs
+        name: image-refs (verify internal image paths resolve)
+        entry: python3 scripts/check_image_refs.py
+        language: system
+        types_or: [html, markdown]
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ After that, every `git commit` will automatically:
 - Minify staged SVGs with `svgo`
 - Block any image still over 1 MB after compression, and warn on images
   between 500 KB and 1 MB (see "Image size policy" below)
+- Verify internal image references in HTML/Markdown actually resolve
+  to a file in the repo (catches typos and orphaned references; external
+  URLs are covered by lychee in the site-health CI workflow)
 - Strip trailing whitespace, fix mixed line endings, ensure files end
   with a final newline
 - Validate YAML and JSON files (`_data/`, `_config.yml`, etc.)

--- a/scripts/check_image_refs.py
+++ b/scripts/check_image_refs.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Verify image references in staged HTML and Markdown resolve to local files.
+
+External URLs (http://, https://, //) and Liquid-templated paths are skipped —
+lychee covers those in CI. This hook focuses on internal refs, which is where
+the value-add is: it catches typos, deleted images that someone forgot to
+update, and the "broken /images/foo.jpg" failure mode that just hit us with
+the dibs-web01 migration.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Catches src="...", image="...", and Markdown ![alt](url).
+# Single-line only; multi-line attribute values are exotic and not worth the
+# regex complexity.
+URL_PATTERNS = [
+    re.compile(r'(?:src|image)=["\']([^"\']+)["\']'),
+    re.compile(r'!\[[^\]]*\]\(([^)\s]+)'),
+]
+
+IMG_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".ico", ".bmp"}
+EXTERNAL_PREFIXES = ("http://", "https://", "//", "data:", "mailto:")
+LIQUID_PAT = re.compile(r"\{[%{]")
+
+
+def is_skippable(url: str) -> bool:
+    if url.startswith(EXTERNAL_PREFIXES):
+        return True
+    if LIQUID_PAT.search(url):
+        return True
+    return False
+
+
+def is_image_path(url: str) -> bool:
+    return Path(url.split("?")[0].split("#")[0]).suffix.lower() in IMG_EXTS
+
+
+def resolve(url: str, repo_root: Path) -> Path:
+    """Resolve a root-relative URL to a filesystem path under repo root."""
+    clean = url.split("?")[0].split("#")[0].lstrip("/")
+    return repo_root / clean
+
+
+def line_of(text: str, pos: int) -> int:
+    return text.count("\n", 0, pos) + 1
+
+
+def check_file(path: Path, repo_root: Path) -> list[tuple[int, str, Path]]:
+    text = path.read_text(errors="replace")
+    failures: list[tuple[int, str, Path]] = []
+    for pattern in URL_PATTERNS:
+        for match in pattern.finditer(text):
+            url = match.group(1)
+            if is_skippable(url) or not is_image_path(url):
+                continue
+            if not url.startswith("/"):
+                # Non-leading-slash relative paths are ambiguous under Jekyll
+                # (depends on the served URL of the page). Skip them rather
+                # than risk false positives — lychee will catch them in CI
+                # via the built _site/.
+                continue
+            target = resolve(url, repo_root)
+            if not target.exists():
+                failures.append((line_of(text, match.start()), url, target))
+    return failures
+
+
+def main(argv: list[str]) -> int:
+    repo_root = Path.cwd()
+    total = 0
+    for arg in argv:
+        path = Path(arg)
+        for line, url, target in check_file(path, repo_root):
+            rel = target.relative_to(repo_root) if target.is_absolute() else target
+            print(
+                f"{path}:{line}: broken image ref {url!r} "
+                f"(looked for {rel})",
+                file=sys.stderr,
+            )
+            total += 1
+    return 1 if total else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Closes #34.

## Summary

Adds a `local` pre-commit hook (`scripts/check_image_refs.py`) that scans staged HTML and Markdown files for image references and fails the commit if a root-relative path doesn't exist in the repo. Pairs with the dibs-web01 migration (#33) — same failure mode (image src points at something that isn't there), now caught at commit time.

**Patterns matched:**
- `src="..."` (HTML `<img>` and similar)
- `image="..."` (Jekyll include parameter used in `people.html`)
- `![alt](...)` (Markdown image syntax)

Then filtered to paths ending in `.png|.jpg|.jpeg|.gif|.svg|.webp|.ico|.bmp`.

**Skipped:**
- External URLs (`http://`, `https://`, `//`, `data:`, `mailto:`)
- Liquid-templated paths (anything containing `{{ ... }}` or `{% ... %}`)
- Non-leading-slash relative paths (ambiguous under Jekyll URL rewriting; lychee catches those in CI via the built `_site/`)

## Why pre-commit + internal-only

External URL checking would make commits depend on network and slow them down. Lychee already covers external refs in `site-health.yml`, so the value-add of the pre-commit hook is the *internal* case: catching typos and orphaned refs at commit time rather than after deploy.

CI inherits the new hook automatically via the existing `pre-commit.yml` workflow.

## Test plan

- [x] `pre-commit run image-refs --all-files` passes on the current repo (no false positives across `*.html`, `*.md`, `_posts/`, `_layouts/`, `_includes/`)
- [x] Synthetic test: a file with `![](/images/this-does-not-exist.jpg)` and `<img src="/images/also-missing.png">` is rejected with file:line:url output
- [x] External URLs and Liquid-templated paths are correctly skipped
- [ ] CI `pre-commit` and `site-health` jobs pass

## Notes

- Stdlib-only Python — no new dependencies.
- Pre-commit hooks only see staged files, so this catches broken refs in newly-changed files. Broken refs that pre-date the hook in untouched files are not surfaced here — lychee in site-health is the safety net for those (modulo the `_site/blog` exclude tracked in #36).

https://claude.ai/code/session_01S5QXfkxZBNSAf2Y1XAD8H7

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5QXfkxZBNSAf2Y1XAD8H7)_