### PR TITLE
Narrow lychee blog exclude to 2015-2018 archive (closes #36)

### DIFF
--- a/.github/workflows/site-health.yml
+++ b/.github/workflows/site-health.yml
@@ -44,12 +44,16 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           # --exclude-path takes a regex matched against file paths.
-          # Skip legacy blog posts (deferred to a content-cleanup phase).
+          # Skip legacy 2015-2018 blog posts (accumulated link rot in
+          # decade-old archival content isn't worth triaging) and the
+          # blog index that aggregates their links. Posts from 2019+
+          # get checked normally.
           args: >-
             --config ./lychee.toml
             --no-progress
             --root-dir ${{ github.workspace }}/_site
-            --exclude-path _site/blog
+            --exclude-path '_site/blog/201[5-8]'
+            --exclude-path '_site/blog/index\.html'
             _site
           output: lychee-report.md
           fail: true


### PR DESCRIPTION
Closes #36.

## Summary

The `site-health.yml` workflow currently passes `--exclude-path _site/blog` to lychee, which skipped *every* blog post — past, present, and future. That means any new blog post with a broken link wouldn't be caught either.

Narrow the exclude to just the legacy archive:

- `_site/blog/201[5-8]` — historical posts where the ~30 known dead links live; triaging decade-old archival content isn't a good ROI
- `_site/blog/index.html` — the blog index aggregates every post's links, so it'd surface the same 2015–2018 errors

Posts from 2019 onward now get full link coverage. New posts catch new rot, which is what the link checker is actually for.

## Test plan

- [x] `bundle exec jekyll build` clean
- [x] `lychee --config ./lychee.toml --no-progress --root-dir _site --exclude-path '_site/blog/201[5-8]' --exclude-path '_site/blog/index\.html' _site` → 89 OK, 0 errors locally (was 84 OK with the broader exclude; the +5 OK are 2019/2020 post links that are now in scope)
- [ ] CI `site-health` passes on the PR

## Notes

- Closes #36 by accepting the "don't bother" path discussed before opening this PR — legacy rot in 2015–2018 stays as-is; new rot gets caught.
- If a 2015–2018 link ever does need fixing for a specific reason, the exclude could be temporarily relaxed for that PR or the link could just be fixed directly (lychee doesn't run on `_posts/` source, only on built `_site/`, so fixing a single legacy link won't trigger a sea of failures from the others).

https://claude.ai/code/session_01S5QXfkxZBNSAf2Y1XAD8H7

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5QXfkxZBNSAf2Y1XAD8H7)_