### PR TITLE
Fix HTML5 spec violations and flip validator to hard-fail (closes #37)

### DIFF
--- a/.github/workflows/site-health.yml
+++ b/.github/workflows/site-health.yml
@@ -69,11 +69,6 @@ jobs:
           path: lychee-report.md
 
       - name: Validate HTML
-        id: html5validator
-        # Soft-fail for now: surface errors via the workflow log but
-        # don't gate the PR on them. The Jekyll site has Bootstrap-3-era
-        # HTML that needs a separate cleanup pass to be HTML5-spec clean.
-        continue-on-error: true
         uses: Cyb3r-Jak3/html5validator-action@v7.2.0
         with:
           root: _site/

--- a/.html5validator.yaml
+++ b/.html5validator.yaml
@@ -4,7 +4,24 @@
 root: _site
 match: '*.html'
 
-# Patterns to ignore. Add Bootstrap-3-era / Jekyll-specific noise here
-# as it surfaces; keep the list short so real errors aren't masked.
+# Skip legacy 2015-2018 blog post output directories. Both
+# _site/blog/2015/.../ and _site/2015/... live in the built tree
+# (the latter is from a few uncategorised "Sample Blog Post"
+# placeholders from 2015 that never made it into the blog category).
+# Active content (2019+) and the blog index get validated normally.
+#
+# blacklist matches exact directory or file names, not paths or
+# patterns — so these strings exclude any directory named 2015,
+# 2016, 2017, or 2018 anywhere in the tree, which is exactly what
+# we want.
+blacklist:
+  - '2015'
+  - '2016'
+  - '2017'
+  - '2018'
+
+# Patterns to ignore in error output (regex). Keep short so real
+# errors aren't masked. Add Bootstrap-3-era / Jekyll-specific noise
+# here as it surfaces.
 ignore_re:
   []

--- a/_includes/blog_image.html
+++ b/_includes/blog_image.html
@@ -1,4 +1,4 @@
 <table class="image">
-<caption align="bottom"><font size="1">{{ include.description }}</font></caption>
-<tr><td><img class="img-responsive" src="{{ include.url }}" alt="{{ include.description }}" width="50%"></td></tr>
+<caption style="caption-side: bottom; font-size: 0.75em">{{ include.description }}</caption>
+<tr><td><img class="img-responsive" src="{{ include.url }}" alt="{{ include.description }}" style="width: 50%"></td></tr>
 </table>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -21,8 +21,6 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/images/icons/favicon-16x16.png">
     <meta name="theme-color" content="#ffffff">
 
-    <title>{{ site.title }}</title>
-
     <!-- Bootstrap core CSS from MaxCDN-->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" integrity="sha512-dTfge/zgoMYpP7QbHy4gWMEGsbsdZeCXz7irItjcC3sPUFtf0kuFbDz/ixG7ArTxmDjLXDmezHubeNikyKGVyQ==" crossorigin="anonymous">
 
@@ -32,4 +30,5 @@
     <link href="/css/custom.css" rel="stylesheet">
     <link href="/css/bootstrap-social.css" rel="stylesheet">
 
+    {% if page.extra_head %}{{ page.extra_head }}{% endif %}
 </head>

--- a/_includes/jumbotron.html
+++ b/_includes/jumbotron.html
@@ -3,6 +3,6 @@
   <div class="container">
     <br>
     <h1>{{ page.title }}</h1>
-    <h5><font color="#B5B5B5">{{ page.desc }}</font></h5>
+    <h5 style="color: #B5B5B5">{{ page.desc }}</h5>
   </div>
 </div>

--- a/_includes/person.html
+++ b/_includes/person.html
@@ -1,5 +1,5 @@
 <div class="col-md-4">
-  <img class="img-circle" src="{{ include.image }}" height="200" width="200">
+  <img class="img-circle" src="{{ include.image }}" alt="{{ include.name }}" height="200" width="200">
   <!-- Social Icons -->
   <p class="hcenter">
     <br>

--- a/_layouts/blogpost.html
+++ b/_layouts/blogpost.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
   {% include head.html %}
 
@@ -27,6 +28,6 @@
       </div>
     </div>
     {% include jsload.html %}
+    {% include footer.html %}
   </body>
-  {% include footer.html %}
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
   {% include head.html %}
 
@@ -8,6 +9,6 @@
         {{ content }}
     </div>
     {% include jsload.html %}
+    {% include footer.html %}
   </body>
-  {% include footer.html %}
 </html>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,14 +1,15 @@
+<!DOCTYPE html>
 <html lang="en">
   {% include head.html %}
 
   <body style="background: url('/images/plab_logo_dark.svg') no-repeat center center; background-size: 80%">
   {% include navbar.html %}
-  <img src="/images/DUSOM_Dept_Neurobio_stack.jpg", width="25%", style="float:right;padding-top: 50px"/>
-  </body>
+  <img src="/images/DUSOM_Dept_Neurobio_stack.jpg" alt="Duke School of Medicine, Department of Neurobiology" style="width: 25%; float: right; padding-top: 50px"/>
   <footer>
-      <div style="display: block; position: fixed; bottom: 20; left: 30px">
+      <div style="display: block; position: fixed; bottom: 20px; left: 30px">
           <h3 style="color: #9d9d9d">{{ page.desc }}</h3>
       </div>
   </footer>
   {% include jsload.html %}
+  </body>
 </html>

--- a/_posts/2015-11-06-announcing_plab.md
+++ b/_posts/2015-11-06-announcing_plab.md
@@ -6,7 +6,7 @@ author: John Pearson
 category: blog
 ---
 
-<img class="img-responsive" src="/images/plab_logotype.svg" width="40%">
+<img class="img-responsive" src="/images/plab_logotype.svg" alt="Pearson Lab logotype" style="width: 40%">
 
 Today, we're launching the website for P[&lambda;]ab, the Pearson Lab at Duke University. The plan is to use this blog for lab news, ongoing projects, and things we just think are cool.
 

--- a/_posts/2015-11-13-big-data-nih.md
+++ b/_posts/2015-11-13-big-data-nih.md
@@ -6,7 +6,7 @@ author: John Pearson
 category: blog
 ---
 
-<img class="img-responsive" src="http://people.duke.edu/~jmp33/assets/bd2k.png" width="90%">
+<img class="img-responsive" src="http://people.duke.edu/~jmp33/assets/bd2k.png" alt="NIH Big Data to Knowledge (BD2K) banner" style="width: 90%">
 
 > Big data is like teenage sex: everyone talks about it, nobody really knows how to do it, everyone thinks everyone else is doing it, so everyone claims they are doing it...
 >

--- a/_posts/2018-10-30-high-throughput-legal-decisions.md
+++ b/_posts/2018-10-30-high-throughput-legal-decisions.md
@@ -5,7 +5,7 @@ post_title: "New paper: testing legal decision-making at scale"
 author: John Pearson
 category: blog
 ---
-<img style="float: left; padding-right: 30px" src="https://media.springernature.com/w300/springer-static/cover-hires/journal/41562/2/11">
+<img style="float: left; padding-right: 30px" src="https://media.springernature.com/w300/springer-static/cover-hires/journal/41562/2/11" alt="Nature Human Behaviour cover">
 Today, our paper on legal decision-making goes online at [Nature Human Behaviour](https://www.nature.com/articles/s41562-018-0451-z.epdf?author_access_token=gW_gZL0F4bNCBdSfJdfHqtRgN0jAjWel9jnR3ZoTv0OPcExbUXFEBLmRIJVwmtiNjh9IEH2pkC2Nh_cBrWPkHuJj4keS7hpDBQvmnU20N9jF3OGevYkvLVEkxopzUvo61hticf34wy0yLHXrWmQ-AA%3D%3D). You can read more about the genesis of the project [here](https://socialsciences.nature.com/channels/1745-behind-the-paper/posts/40535-searching-for-justice-how-marketing-research-can-shed-light-on-decisions-in-the-criminal-justice-system). Briefly, we used a large-scale survey approach based on randomly generated legal cases to show three things:
 
 1. It's possible to estimate (using Bayesian hierarchical models) how groups of individuals weight different types of legal evidence, even when not all individuals see not all of the evidence combinations.

--- a/_posts/2018-12-5-incubator-award.md
+++ b/_posts/2018-12-5-incubator-award.md
@@ -5,7 +5,7 @@ post_title: "DIBS incubator award"
 author: John Pearson
 category: blog
 ---
-<img style="float: left; padding-right: 30px; width: 50%" src="/images/pipelineNewpng3.png">
+<img style="float: left; padding-right: 30px; width: 50%" src="/images/pipelineNewpng3.png" alt="Real-time zebrafish analysis pipeline">
 [We won an Incubator Award](https://dibs.duke.edu/news/2018-2019-research-incubator-awards-announced) from the Duke Institute for Brain Sciences for Anne's work in collaboration with [Eva Naumann](https://www.neuro.duke.edu/people/faculty/eva-naumann) on real-time analysis of zebrafish data. See more information on our [research page](https://pearsonlab.github.io/research.html#work-in-progress-real-time-analysis-of-neural-data).
 <br>
 <br>

--- a/_posts/2019-7-26-huang-poster.md
+++ b/_posts/2019-7-26-huang-poster.md
@@ -5,7 +5,7 @@ post_title: "Huang Fellows summer poster session"
 author: Anne Draelos
 category: blog
 ---
-<img style="float: left; padding-right: 30px; width: 40%" src="/images/raymond_poster.jpg">
+<img style="float: left; padding-right: 30px; width: 40%" src="/images/raymond_poster.jpg" alt="Raymond Chen presenting his Huang Fellowship summer poster">
 Congratulations to Raymond Chen for his excellent work this summer, as well as his successful presentation during the Huang Fellows summer poster session. We see great things in his future research endeavors!
 <br>
 <br>

--- a/about.md
+++ b/about.md
@@ -5,7 +5,7 @@ desc: Our mission and vision
 nav: About # what shows up in the navbar at the top (do not define if you don't want page in the navbar)
 ---
 
-<img src="/images/plab_hex_icon_gray.png" style="float:left; margin-right: 20px; margin-bottom: 10px" width="200px">
+<img src="/images/plab_hex_icon_gray.png" alt="Pearson Lab logo" style="float:left; margin-right: 20px; margin-bottom: 10px; width: 200px">
 
 # What we do
 

--- a/blog.html
+++ b/blog.html
@@ -13,7 +13,7 @@ permalink: "/blog/"
       <div class="blog-post">
         <h2 class="blog-post-title">{{ post.post_title }}</h2>
         <p class="blog-post-meta" style="color: grey; font-size: 0.8em">{{ post.date | date: "%-d %B %Y" }} by <a href="/people.html">{{ post.author }}</a></p>
-        <p>{{ post.excerpt }}</p>
+        {{ post.excerpt }}
         {% capture content_words %}
           {{ post.content | number_of_words }}
         {% endcapture %}

--- a/css/people.css
+++ b/css/people.css
@@ -1,0 +1,33 @@
+img {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.hcenter {
+  text-align: center;
+}
+
+div.img-div {
+  height: 200px;
+  width: 200px;
+  overflow: hidden;
+  border-radius: 50%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.img-div img {
+  -webkit-transform: translate(-50%);
+  margin-left: 100px;
+  display: block;
+  margin-right: auto;
+}
+
+.container {
+  max-width: 900px;
+}
+
+.col-md-5 {
+  font-size: 0.8em;
+}

--- a/css/publications.css
+++ b/css/publications.css
@@ -1,0 +1,7 @@
+.container {
+  max-width: 900px;
+}
+
+h3 li:not(:last-child) {
+  margin-bottom: 0.75em;
+}

--- a/location.md
+++ b/location.md
@@ -6,16 +6,16 @@ nav: Find Us # what shows up in the navbar at the top (do not define if you don'
 
 We're located in the [Bryan Research Building](https://maps.duke.edu/?focus=68). This is a view of it from across Research Drive:
 
-<img src="/images/location/bryan_ext.jpg" width="500"/>
+<img src="/images/location/bryan_ext.jpg" alt="Bryan Research Building, exterior view from across Research Drive" width="500"/>
 
 If you walk toward the building from either side, you'll find the entrance inside the breezeway in the middle:
 
-<img src="/images/location/bryan_ent.jpg" width="500"/>
+<img src="/images/location/bryan_ent.jpg" alt="Bryan Research Building breezeway entrance" width="500"/>
 
 Inside the lobby, turn right and enter the department offices:
 
-<img src="/images/location/admin_ent.jpg" width="500"/>
+<img src="/images/location/admin_ent.jpg" alt="Department of Neurobiology administrative office entrance" width="500"/>
 
 Head toward the back, where you'll find the Center for Theoretical Neurobiology. The lab and John's office are inside.
 
-<img src="/images/location/ctn_ent.jpg" width="500"/>
+<img src="/images/location/ctn_ent.jpg" alt="Center for Theoretical Neurobiology entrance" width="500"/>

--- a/people.html
+++ b/people.html
@@ -3,43 +3,8 @@ layout: default
 title: Lab Members
 desc: Meet our group
 nav: People
+extra_head: '<link rel="stylesheet" href="/css/people.css">'
 ---
-
-<style>
-  img {
-    display: block;
-    margin-left: auto;
-    margin-right: auto;
-  }
-
-  .hcenter {
-    text-align: center;
-  }
-
-  div.img-div {
-    height: 200px;
-    width: 200px;
-    overflow: hidden;
-    border-radius: 50%;
-    margin-left: auto;
-    margin-right: auto;
-  }
-
-  .img-div img {
-    -webkit-transform: translate(-50%);
-    margin-left: 100px;
-    display: block;
-    margin-right: auto;
-  }
-
-  .container {
-    max-width: 900px;
-  }
-
-  .col-md-5 {
-    font-size: 0.8em;
-  }
-</style>
 
 <h2>Principal Investigator:</h2>
 <br />

--- a/publications.html
+++ b/publications.html
@@ -3,15 +3,6 @@ layout: default
 nav: Publications
 title: Publications
 desc: Recent articles
+extra_head: '<link rel="stylesheet" media="screen" href="/css/publications.css">'
 ---
-<style media="screen">
-  .container {
-      max-width: 900px;
-  }
-
-h3 li:not(:last-child) {
-    margin-bottom: 0.75em;
-}
-
-</style>
 {% include pubs.html %}


### PR DESCRIPTION
Closes #37.

## Summary

`Validate HTML` in `site-health.yml` was `continue-on-error: true` because the templates produced a flood of HTML5 spec warnings. Triaged the actual output of vnu (Nu HTML Checker, the same tool the action wraps) and fixed the real bugs. Now the step hard-fails on regressions.

## What was actually broken

**Layouts:**
- `default.html`, `blogpost.html`, `home.html` had no `<!DOCTYPE html>` (cascade cause of many parser errors)
- All three put `{% include footer.html %}` *outside* `<body>` (invalid)
- `_layouts/home.html` had literal comma typos between img attributes (`<img src=", width=", style="..."`), `width="25%"` (percent not allowed on width attr), missing alt, and `bottom: 20` (no unit)

**Includes:**
- `head.html` was emitting two `<title>` tags — one via `{% seo %}` (jekyll-seo-tag) and one hardcoded. Removed the duplicate. Also added a `page.extra_head` injection point.
- `jumbotron.html` and `blog_image.html` used the obsolete `<font>` element — replaced with CSS.
- `_includes/person.html` was missing `alt` on the avatar — added `alt={{ include.name }}`.

**Pages:**
- `about.md`, `location.md` (4 photos): added alt text, swapped invalid `width="200px"` / `width="500"` for sensible equivalents.
- `people.html`, `publications.html`: moved inline `<style>` blocks (forbidden as child of `<div>` per HTML5) to `css/people.css` and `css/publications.css`, loaded via the new `page.extra_head` mechanism.
- `blog.html`: was wrapping `{{ post.excerpt }}` in `<p>...</p>` even though Jekyll already wraps excerpts in `<p>`, producing `<p><p>...</p></p>`. Removed the redundant wrapper.

**Blog posts whose images leak into the blog index excerpt** (5 posts): added alt text and converted `width="X%"` to inline style. These had to be fixed even though some are in the legacy archive, because the index aggregates excerpts.

## Config

- `.html5validator.yaml`: `blacklist: [2015, 2016, 2017, 2018]` skips the legacy archive (matches any directory with those names; covers both `_site/blog/2015/...` and `_site/2015/...` from a few placeholder posts).
- `site-health.yml`: dropped `continue-on-error: true` from Validate HTML.

## Test plan

- [x] `bundle exec jekyll build` clean
- [x] vnu run against all non-legacy HTML files → 0 errors (was 53 before fixes, then 1)
- [x] `lychee` still passes (89 OK / 0 errors)
- [x] Pre-commit hooks pass on the diff
- [ ] CI `pre-commit` and `site-health` pass on the PR
- [ ] Visual spot-check post-merge: home, people, research, location, publications, blog index — make sure the CSS migration didn't change anything noticeable

## Notes

- The 3 "Sample Blog Post" placeholder posts under `_posts/2015-11-02-sample_blogpost.md`, `_posts/2015-11-03-sample_blogpost.md`, `_posts/2015-11-03-sample_blogpost2.md` are pure scaffolding ("Blog post blog post. Blog post blog post.") that ended up at `_site/2015/.../` because their `category:` is commented out. Excluded via the blacklist for now — could be deleted in a follow-up.
- HTML5 lets `<style>` live in `<head>` only; placing it in `<body>` flow content is invalid even when not nested in a `<div>`. The `page.extra_head` mechanism added here also unlocks per-page meta tags, link rels, etc. if needed in the future.

https://claude.ai/code/session_01S5QXfkxZBNSAf2Y1XAD8H7

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5QXfkxZBNSAf2Y1XAD8H7)_