### PR TITLE
Publications: remove year-filter chips

### DIFF
--- a/_includes/pubs.html
+++ b/_includes/pubs.html
@@ -9,7 +9,6 @@
     adding/removing a member there propagates here automatically.
   - Auto-derived type badge (journal / preprint / conference) based
     on the venue string — no extra data entry required.
-  - Year-filter chips at the top let visitors narrow to a single year.
 {%- endcomment -%}
 
 {%- assign all_lab_people = "" | split: "" -%}
@@ -37,13 +36,6 @@
 <p>This list is not guaranteed to be up to date, but the lab's complete publications can be found <a href="https://scholar.google.com/citations?user=4whjDosAAAAJ&hl=en">here</a>.</p>
 
 {% assign sorted_pubs = site.data.publications | group_by_exp:'item', 'item.issued.first.year' | sort: 'name' | reverse %}
-
-<div class="year-filter" role="toolbar" aria-label="Filter publications by year">
-  <button type="button" class="year-chip active" data-year="all">All</button>
-  {% for year in sorted_pubs %}
-  <button type="button" class="year-chip" data-year="{{ year.name }}">{{ year.name }}</button>
-  {% endfor %}
-</div>
 
 <div class="pubs-list">
 {% for year in sorted_pubs %}
@@ -83,19 +75,3 @@
 </section>
 {% endfor %}
 </div>
-
-<script>
-  (function () {
-    var chips = document.querySelectorAll('.year-filter .year-chip');
-    var sections = document.querySelectorAll('.pubs-year');
-    chips.forEach(function (btn) {
-      btn.addEventListener('click', function () {
-        var target = btn.dataset.year;
-        chips.forEach(function (b) { b.classList.toggle('active', b === btn); });
-        sections.forEach(function (s) {
-          s.style.display = (target === 'all' || s.dataset.year === target) ? '' : 'none';
-        });
-      });
-    });
-  })();
-</script>

--- a/css/publications.css
+++ b/css/publications.css
@@ -2,35 +2,6 @@
   max-width: 900px;
 }
 
-/* Year filter chips */
-.year-filter {
-  margin: 0 0 1.5em 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4em;
-}
-
-.year-filter .year-chip {
-  padding: 0.25em 0.7em;
-  border: 1px solid #ccc;
-  background: #fff;
-  border-radius: 12px;
-  font-size: 0.9em;
-  cursor: pointer;
-  color: #444;
-  line-height: 1.4;
-}
-
-.year-filter .year-chip:hover {
-  background: #f5f5f5;
-}
-
-.year-filter .year-chip.active {
-  background: #337ab7;
-  color: #fff;
-  border-color: #337ab7;
-}
-
 /* Per-paper venue-type badge (auto-derived from container-title) */
 .pub-badge {
   display: inline-block;


### PR DESCRIPTION
## Summary

Drop the year-filter chips added in PR #45 — they're not wanted.

Everything else from #45 stays: title hyperlinks, bold lab authors (first-initial + last-name match against `_data/people.yml`), and auto-derived venue-type badges (`PREPRINT` / `JOURNAL` / `CONFERENCE`).

Removed:
- The `<div class="year-filter">` block + per-year `<button>` elements in `_includes/pubs.html`
- The toggle JS at the bottom of the include
- The `.year-filter` / `.year-chip` CSS rules in `css/publications.css`
- The now-orphaned mention of chips in the include's header comment

The `data-year` attribute on each `<section class="pubs-year">` is harmless and stays; happy to drop it too if you'd rather a fully clean DOM.

## Test plan

- [x] `bundle exec jekyll build` clean
- [x] vnu HTML5 → 0 errors on `_site/publications.html`
- [x] No `year-chip` or chip-toggle JS in built output
- [ ] CI passes
- [ ] Visual spot-check post-merge

https://claude.ai/code/session_01S5QXfkxZBNSAf2Y1XAD8H7

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5QXfkxZBNSAf2Y1XAD8H7)_