### PR TITLE
People: drop role section headers; one unified card flow

### DIFF
--- a/people.html
+++ b/people.html
@@ -7,28 +7,27 @@ extra_head: '<link rel="stylesheet" href="/css/people.css">'
 ---
 {% assign people = site.data.people %}
 {% assign roles = "postdocs|graduate_students|research_associates|undergraduates" | split: "|" %}
-{% assign labels = "Postdocs|Graduate Students|Research Associates|Undergraduate Students" | split: "|" %}
 
-<h2>Principal Investigator:</h2>
-<br />
-<div class="row full-width">
-  {% include person.html person=people.pi %}
-</div>
-
+{%- comment -%}
+  Build one flat list of all current members (PI first, then each role
+  in the order defined above). Cards just flow in this order — no
+  per-role section headers. Each card's `title` field still shows the
+  individual role under the name.
+{%- endcomment -%}
+{% assign current_members = "" | split: "" %}
+{% if people.pi %}{% assign current_members = current_members | push: people.pi %}{% endif %}
 {% for role in roles %}
-  {% assign label = labels[forloop.index0] %}
-  {% assign all = people[role] %}
-  {% assign current = all | where_exp: "p", "p.current != false" %}
-  {% if current.size > 0 %}
-    <h2>{{ label }}:</h2>
-    <br />
-    <div class="row full-width">
-      {% for person in current %}
-        {% include person.html person=person %}
-      {% endfor %}
-    </div>
-  {% endif %}
+  {% assign role_current = people[role] | where_exp: "p", "p.current != false" %}
+  {% for person in role_current %}
+    {% assign current_members = current_members | push: person %}
+  {% endfor %}
 {% endfor %}
+
+<div class="row full-width">
+  {% for person in current_members %}
+    {% include person.html person=person %}
+  {% endfor %}
+</div>
 
 <br />
 <h2>Former members</h2>


### PR DESCRIPTION
## Summary

Drop the role-based section headers on the people page ("Principal Investigator:", "Postdocs:", "Graduate Students:", "Research Associates:", "Undergraduate Students:"). Current members now flow as one unified grid in YAML order:

1. PI (`people.pi`)
2. Postdocs (current, in YAML order)
3. Graduate Students (current, in YAML order)
4. Research Associates (current, in YAML order)
5. Undergraduate Students (current, in YAML order)

Each card still displays the individual `title` field under the name, so role context is preserved at the per-person level.

Former members section is unchanged (still grouped by role with `<h3>` subheadings — those are listed as text, not cards).

## Test plan

- [x] `bundle exec jekyll build` clean
- [x] vnu HTML5 → 0 errors on `_site/people.html`
- [x] No role section headers in built output
- [x] Five cards render in expected order (John, Trevor, David, Shiyang, Caitlin) at 1400×900
- [x] Former members section unchanged
- [ ] CI passes
- [ ] Visual spot-check post-merge

## Note worth addressing

**John's card no longer shows any role context** because his entry in `_data/people.yml` has no `title` field — the section header was carrying that information before. Adding `title: Principal Investigator` to his entry would label him; one-line YAML edit, not in this PR since it's an editorial decision (you might want a different label or none at all).

https://claude.ai/code/session_01S5QXfkxZBNSAf2Y1XAD8H7

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5QXfkxZBNSAf2Y1XAD8H7)_