### PR TITLE
people: fix YAML indentation for Ganchao Wei entry

### DIFF
--- a/_data/people.yml
+++ b/_data/people.yml
@@ -54,14 +54,14 @@ pi:
 
 postdocs:
   - name: Ganchao Wei
-      current: true
-      image: /images/ganchao_john_sq.JPG
-      site: https://weigcdsb.github.io/
-      email: ganchao.wei@duke.edu
-      desc: >-
-        Ganchao plays around with stats / ML / AI, mainly motivated by and applied to neuroscience. 
-        He is currently into deep generative models (diffusion-/flow-based) and
-        causal representation learning.
+    current: true
+    image: /images/ganchao_john_sq.JPG
+    site: https://weigcdsb.github.io/
+    email: ganchao.wei@duke.edu
+    desc: >-
+      Ganchao plays around with stats / ML / AI, mainly motivated by and applied to neuroscience.
+      He is currently into deep generative models (diffusion-/flow-based) and
+      causal representation learning.
 
   - name: Jeff MacInnes
     current: false


### PR DESCRIPTION
## Summary

- The Ganchao Wei postdoc entry was added with 6-space key indentation instead of 4, causing a `Psych::SyntaxError` in Jekyll's YAML parser and breaking the site build entirely
- Also removed a trailing space from the `desc` content
- The fix corrects all keys to 4-space indent and the `desc` block scalar content to 6-space, matching the rest of the file

## Root cause

Direct pushes to master on 2026-05-19 added the entry with misaligned indentation; the `yamllint`/`check-yaml` pre-commit CI checks flagged it at the time but the commit landed anyway.

## Test plan

- [ ] `bundle exec jekyll build` succeeds locally with fixed YAML
- [ ] `python3 -c "import yaml; yaml.safe_load(open('_data/people.yml'))"` exits 0
- [ ] Site health CI (lychee + HTML validator) passes
- [ ] Ganchao's card renders on the People page

🤖 Generated with [Claude Code](https://claude.com/claude-code)