### PR TITLE
ci: upgrade actions/checkout v4 → v6 (Node.js 24)

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Need full history so the diff range below can resolve the
           # base/before SHA against actual commits, not just HEAD.

--- a/.github/workflows/site-health.yml
+++ b/.github/workflows/site-health.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/update-publications.yml
+++ b/.github/workflows/update-publications.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Updates `actions/checkout@v4` → `@v6` in all three workflows (`pre-commit`, `site-health`, `update-publications`)
- v6 is the first release with Node.js 24 support; GitHub is forcing Node 24 as the default on June 2nd, 2026

## Test plan

- [ ] pre-commit CI passes on this PR
- [ ] site-health CI passes on this PR
- [ ] No Node.js 20 deprecation warnings in run annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)