### PR TITLE
Guard author lists and publisher URLs against Scholar regressions

### DIFF
--- a/_data/publications.yaml
+++ b/_data/publications.yaml
@@ -17,7 +17,7 @@
   container-title: Nature
   publisher: Nature Publishing Group UK
   page: 1-9
-  URL: https://www.biorxiv.org/content/10.64898/2026.01.20.699515.abstract
+  URL: https://www.nature.com/articles/s41586-026-10510-x
 - id: subramanian2026selective
   type: article-journal
   author:
@@ -783,6 +783,8 @@
   author:
   - family: Draelos
     given: Anne
+  - family: Naumann
+    given: Eva A
   - family: Pearson
     given: John M
   issued:

--- a/scholar_scraper.py
+++ b/scholar_scraper.py
@@ -8,6 +8,7 @@ import yaml
 import sys
 import re
 import time
+import urllib.parse
 from datetime import date
 from scholarly import scholarly, ProxyGenerator
 
@@ -358,6 +359,19 @@ def is_preprint_venue(venue):
     """True if a container-title names a preprint server, not a journal."""
     return bool(PREPRINT_VENUE_RE.search(venue or ''))
 
+# Hosts that serve preprints. Matched against the URL's host only, so a
+# published paper whose title happens to contain "arxiv" isn't caught.
+PREPRINT_HOST_RE = re.compile(
+    r'(^|\.)(biorxiv|medrxiv|arxiv|chemrxiv|psyarxiv|ssrn|osf)\.(org|io|com|net)$', re.I)
+
+def is_preprint_url(url):
+    """True if a URL points at a preprint server rather than a publisher."""
+    try:
+        host = urllib.parse.urlsplit(url or '').hostname or ''
+    except ValueError:
+        return False
+    return bool(PREPRINT_HOST_RE.search(host))
+
 def looks_truncated(new, old):
     """
     True if `new` is a shortened form of `old` rather than a real retitling.
@@ -396,6 +410,34 @@ def merge_entry_fields(old, new):
             if old_venue and re.fullmatch(
                     re.escape(old_venue) + r'[,\s]+\d+\s*\(\d+\)', value.strip()):
                 print(f"    ! keeping '{old_venue}' over '{value}'", flush=True)
+                continue
+
+        # The venue guard above stops a published paper being relabelled as a
+        # preprint, but the link is a separate field: Scholar has flipped a
+        # Nature URL back to a bioRxiv abstract while the venue stayed right.
+        #
+        # Only guard this for papers we believe are published. An entry whose
+        # venue is still bioRxiv genuinely is a preprint, and a bioRxiv link
+        # is the canonical one for it — blocking that would freeze the link at
+        # whatever mirror happened to be seen first.
+        if key == 'URL':
+            old_url = old.get('URL') or ''
+            venue_now = merged.get('container-title') or ''
+            published = bool(venue_now) and not is_preprint_venue(venue_now)
+            if published and old_url and not is_preprint_url(old_url) and is_preprint_url(value):
+                print(f"    ! keeping publisher URL over preprint URL '{value}' "
+                      f"(venue is '{venue_now}')", flush=True)
+                continue
+
+        # Scholar sometimes returns a shortened author list for a paper it
+        # already had in full (it dropped a middle author from the NeurIPS
+        # entry). Losing a co-author is worse than missing a late addition,
+        # so only accept a list that is at least as long as the stored one.
+        if key == 'author' and isinstance(value, list):
+            old_authors = old.get('author') or []
+            if len(value) < len(old_authors):
+                print(f"    ! keeping {len(old_authors)} stored authors over "
+                      f"{len(value)} fetched", flush=True)
                 continue
 
         merged[key] = value


### PR DESCRIPTION
The first unattended scraper run under the new merge logic (`9a7b0bf`) walked two fields backwards. Data integrity held — 92 entries, no duplicates, manual overrides intact — but two guards were missing.

## What regressed

| Entry | Field | Before | After |
|---|---|---|---|
| `schreiner2026synaptic` | URL | `nature.com/articles/s41586-026-10510-x` | `biorxiv.org/…699515.abstract` |
| `draelos2020online` | author | Draelos; **Naumann**; Pearson | Draelos; Pearson |

The venue guard held in both cases — `schreiner2026synaptic` still correctly reads "Nature". The link and the author list were simply never guarded.

## Fixes

**URL** — reject a preprint-host URL that would replace a publisher URL, but only for entries we believe are published. An entry whose venue is still bioRxiv genuinely *is* a preprint and its bioRxiv link is canonical; guarding those would freeze the link at whichever mirror was seen first. `wei2026dynamic` is exactly that case and is deliberately left alone. Matching is on the URL **host**, so a publisher URL with "arxiv" in the path isn't caught.

**author** — only accept a list at least as long as the stored one. Losing a co-author is worse than being slow to add one.

## Data repair

Restored the Nature URL (verified HTTP 200) and re-added Naumann in her original position. Left alone: the escholarship URL change (publisher → publisher, not a regression) and `wei2026dynamic`'s bioRxiv URL.

## Verification

Replayed the exact payload from `9a7b0bf` against the repaired data — neither field is damaged now, and both guards log their reasoning. Full suite passes: merge, selection, badge overrides, manual CCN metadata, and the new guard tests, plus a no-op reconcile that rewrites 0 ids and leaves 0 duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)